### PR TITLE
Replacing hardcoded base URL strings with references to settings objects

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -127,7 +127,7 @@ Hyrax = {
         if ($("meta[name='current-user']").length === 0)
             return;
         <% if Hyrax.config.realtime_notifications? %>
-        var consumer = ActionCable.createConsumer("<%= ::DeepBlueDocs::Application.config.relative_url_root %>" + "<%= Hyrax::Engine.routes.url_helpers.notifications_endpoint_path %>");
+        var consumer = ActionCable.createConsumer(RELATIVE_URL_ROOT + "<%= Hyrax::Engine.routes.url_helpers.notifications_endpoint_path %>");
         consumer.subscriptions.create("Hyrax::NotificationsChannel", {
             connected: function(data) {
                 this.perform("update_locale", { locale: $('html').attr('lang') });

--- a/app/assets/javascripts/hyrax/collections_utils.es6
+++ b/app/assets/javascripts/hyrax/collections_utils.es6
@@ -41,7 +41,7 @@ class AddParticipants {
 
     $.ajax({
       type: 'POST',
-      url: "/data" + url,
+      url: RELATIVE_URL_ROOT + url,
       data: serialized
     })
       .done(function(response) {

--- a/app/assets/javascripts/hyrax/file_manager/sorting.es6
+++ b/app/assets/javascripts/hyrax/file_manager/sorting.es6
@@ -19,7 +19,7 @@ export default class SortManager {
     this.element.removeClass("success")
     this.element.removeClass("failure")
     let persisting = $.post(
-      `/data/concern/${this.class_name}/${this.id}.json`,
+      `${RELATIVE_URL_ROOT}concern/${this.class_name}/${this.id}.json`,
       this.params()
     ).done((response) => {
       this.element.data('version', response.version)

--- a/app/assets/javascripts/hyrax/user_search.js
+++ b/app/assets/javascripts/hyrax/user_search.js
@@ -16,7 +16,7 @@
           callback(data);
         },
         ajax: { // Use the jQuery.ajax wrapper provided by Select2
-          url: "/data/users.json",
+          url: RELATIVE_URL_ROOT + "users.json",
           dataType: "json",
           data: function (term, page) {
             return {

--- a/app/helpers/deepblue/email_helper.rb
+++ b/app/helpers/deepblue/email_helper.rb
@@ -47,7 +47,7 @@ module Deepblue
       rv = Settings.hostname
       return rv unless rv.nil?
       # then we are in development mode
-      "http://localhost:3000/data/"
+      "http://localhost:3000/#{Settings.relative_url_root}/"
     end
 
     def self.log( class_name: 'UnknownClass',

--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,1 +1,7 @@
 <!-- link rel="icon" href="favicon.ico" type="image/ico"/ -->
+
+<!-- Set BASE_URL for use in JavaScript that won't have access to config helpers -->
+<script type="text/javascript">
+    // RELATIVE_ROOT_URL makes sure that a trailing slash is present
+    var RELATIVE_URL_ROOT = '<%= Settings.relative_url_root %>'.replace(/\/?$/, '/');
+</script>

--- a/app/views/hyrax/static/dbd-documentation-guide.html.erb
+++ b/app/views/hyrax/static/dbd-documentation-guide.html.erb
@@ -78,7 +78,7 @@ include a codebook, a field notebook, or a README file.</span>
 datasets on Deep Blue Data, Research Data Services requests
 that researchers include documentation to accompany the data
 either in separate files
-(see <a href="/data/Deep_Blue_Data_Example_Readme.txt">this readme</a> as an example)
+(see <a href="<%= Settings.relative_url_root %>>/Deep_Blue_Data_Example_Readme.txt">this readme</a> as an example)
 or embedded within the data files
 themselves. Ideally, documentation would be produced throughout
 the research process, making it easy to compile and combine

--- a/config/application.rb
+++ b/config/application.rb
@@ -166,8 +166,6 @@ module DeepBlueDocs
     # URL for logging the user out of Cosign
     config.logout_prefix = "https://weblogin.umich.edu/cgi-bin/logout?"
 
-    # FIXME: This unless reveals bugs. There are places in the app that hard-code the
-    #        /data prefix and the tests break when it is set.
     # See references to: DeepBlueDocs::Application.config.relative_url_root
     config.relative_url_root = Settings.relative_url_root unless Rails.env.test?
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -331,7 +331,7 @@ Hyrax.config do |config|
 
   # override the path used for branding
   # the rest of the code assumes that the this path is symlinked to public/branding
-  config.instance_variable_set( :@branding_path, Rails.root.join( 'data', 'branding' ) )
+  config.instance_variable_set( :@branding_path, Rails.root.join( Settings.relative_url_root, 'branding' ) )
 
 end
 

--- a/config/locales/deepblue.en.yml
+++ b/config/locales/deepblue.en.yml
@@ -98,9 +98,7 @@ en:
       generic_work:
         describe_work: >
           Please provide information about your data set (referred to as a "work") in the following fields, keeping in
-          mind that your responses will enable people to discover, identify, and understand your data. If you are
-          uncertain of how to complete any of these fields, we recommend that you read or refer to the
-          <a href="/data/metadata-guidance">Guide to Metadata</a> in Deep Blue Data’s Help pages.
+          mind that your responses will enable people to discover, identify, and understand your data.
         title: >
           Provide a descriptive name for the Work. Consider including the words “data” or “dataset” and terms related to
           the methods, discipline, and topic associated with your research.
@@ -129,7 +127,6 @@ en:
           'The file format and/or physical medium of datasets contained in the work.'
         on_behalf_of_html: >
            If you are depositing data on behalf of someone else, please select the email of that person below.
-           <a href="/data/dashboard">More information on proxies</a>
         keyword: >
           Enter any terms or topics related to the research subject or methods that you would like associated with the
           Work.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,10 +12,7 @@ hostname: default.deepblue.lib.umich.edu
 # Relative URL segment at which the application resides, used to compute links
 # and assets. Used instead of RAILS_RELATIVE_URL_ROOT everywhere, because the
 # behavior with the environment variable has proven inconsistent.
-# FIXME: There are multiple places in the application that depend on this
-#        path being /data. They should all be cleaned up to generate paths
-#        based on the configuration of Rails / ActionController.
-relative_url_root: /data
+relative_url_root: /
 
 # Does not appear to be used anywhere
 # from_email: 'deepblue@umich.edu'


### PR DESCRIPTION
Normalizing where and how the relative URL root is set and changing all places where the application base had been hardcoded to instead use a config method.  Also injected a JavaScript variable at the page level so that base path references in JS components could be eliminated.