### PR TITLE
Read ENV for overriding Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@ config/*.p12
 config/skylight.yml
 config/settings.local.yml
 config/settings/*.local.yml
+.secrets.sh
 

--- a/.secrets.sh.example
+++ b/.secrets.sh.example
@@ -1,9 +1,11 @@
+export RAILS_ENV='development'
+export RAILS_MAX_THREADS=5
+export PORT=3000
+
 export DATACORE__HOSTNAME='deepblue.local'
 export DATACORE__GLOBUS_DIR='/deepbluedata-globus'
 export DATACORE__USER=$USER
 export DATACORE__NOTIFICATION_EMAIL=$DATACORE__USER'@iu.edu'
-export DATACORE__RAILS_MAX_THREADS=5
-export DATACORE__PORT=3000
 export DATACORE__WEB_CONCURRENCY=2
 export DATACORE__TMPDIR='/tmp'
 export DATACORE__FILE_DERIVATIVES_DIR='/datacore-prep/fedora-extract'
@@ -28,7 +30,7 @@ export DATACORE__FEDORA__URL='http://127.0.0.1:8984/rest'
 export DATACORE__FEDORA__BASE_PATH='/deepbluedata-dev'
 
 export DATACORE__RAILS__SECRET_KEY_BASE='123456789abcdef'
-export DATACORE__RAILS__DATABASE__DATABASE=='db/development.sqlite3'
+export DATACORE__RAILS__DATABASE__DATABASE='db/development.sqlite3'
 
 export DATACORE__REDIS__HOST=localhost
 export DATACORE__REDIS__PORT=6379

--- a/.secrets.sh.example
+++ b/.secrets.sh.example
@@ -1,0 +1,37 @@
+export DATACORE__HOSTNAME='deepblue.local'
+export DATACORE__GLOBUS_DIR='/deepbluedata-globus'
+export DATACORE__USER=$USER
+export DATACORE__NOTIFICATION_EMAIL=$DATACORE__USER'@iu.edu'
+export DATACORE__RAILS_MAX_THREADS=5
+export DATACORE__PORT=3000
+export DATACORE__WEB_CONCURRENCY=2
+export DATACORE__TMPDIR='/tmp'
+export DATACORE__FILE_DERIVATIVES_DIR='/datacore-prep/fedora-extract'
+export DATACORE__JAVA_IO_DIR='/datacore-prep/fedora-extract'
+
+export DATACORE__EZID__HOST=ezidhost.invalid
+export DATACORE__EZID__PORT=443
+export DATACORE__EZID__USER=eziduser.invalid
+export DATACORE__EZID__PASSWORD=ezidpassword.invalid
+export DATACORE__EZID__SHOULDER=doi:10.5072/FK2
+export DATACORE__EZID__TIMEOUT=300
+
+export DATACORE__HYRAX__CONTACT_EMAIL=$DATACORE__USER'@iu.edu'
+# export DATACORE__HYRAX__MINTER_STATEFILE=$MINTER_FILE
+export DATACORE__HYRAX__REDIS_NAMESPACE='deepbluedata-dev'
+
+export DATACORE__JIRA_USERNAME=jirausername.invalid
+export DATACORE__JIRA_PASSWORD=jirapassword.invalid
+export DATACORE__JIRA_SITE_URL='https://tools.lib.umich.edu'
+
+export DATACORE__FEDORA__URL='http://127.0.0.1:8984/rest'
+export DATACORE__FEDORA__BASE_PATH='/deepbluedata-dev'
+
+export DATACORE__RAILS__SECRET_KEY_BASE='123456789abcdef'
+export DATACORE__RAILS__DATABASE__DATABASE=='db/development.sqlite3'
+
+export DATACORE__REDIS__HOST=localhost
+export DATACORE__REDIS__PORT=6379
+export DATACORE__REDIS__THREAD_SAFE=true
+
+export DATACORE__SOLR__URL='http://127.0.0.1:8983/solr/deepbluedata-dev'

--- a/app/controllers/hyrax/data_sets_controller.rb
+++ b/app/controllers/hyrax/data_sets_controller.rb
@@ -378,7 +378,7 @@ module Hyrax
       require 'zip'
       require 'tempfile'
 
-      tmp_dir = ENV['TMPDIR'] || "/tmp"
+      tmp_dir = Settings.tmpdir || '/tmp'
       tmp_dir = Pathname.new tmp_dir
       # Deepblue::LoggingHelper.debug "Download Zip begin tmp_dir #{tmp_dir}"
       Deepblue::LoggingHelper.bold_debug [ "zip_download begin", "tmp_dir=#{tmp_dir}" ]

--- a/app/controllers/provenance_log_controller.rb
+++ b/app/controllers/provenance_log_controller.rb
@@ -54,7 +54,7 @@ class ProvenanceLogController < ApplicationController
                                            ::Deepblue::LoggingHelper.called_from,
                                            "" ]
 
-    tmp_dir = ENV['TMPDIR'] || "/tmp"
+    tmp_dir = Settings.tmpdir || '/tmp'
     tmp_dir = Pathname.new tmp_dir
     Deepblue::LoggingHelper.bold_debug [ "zip_log_download begin", "tmp_dir=#{tmp_dir}" ]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,7 @@ module DeepBlueDocs
 
     # For properly generating URLs and minting DOIs - the app may not by default
     # Outside of a request context the hostname needs to be provided.
-    config.hostname = ENV['APP_HOSTNAME'] || Settings.hostname
+    config.hostname = Settings.hostname
     # puts "config.hostname=#{config.hostname}"
 
     ## configure box
@@ -100,7 +100,7 @@ module DeepBlueDocs
       config.globus_dir = '/tmp/deepbluedata-globus'
       Dir.mkdir config.globus_dir unless Dir.exist? config.globus_dir
     else
-      config.globus_dir = ENV['GLOBUS_DIR'] || '/deepbluedata-globus'
+      config.globus_dir = Settings.globus_dir
     end
     # puts "globus_dir=#{config.globus_dir}"
     config.globus_dir = Pathname.new config.globus_dir

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -7,12 +7,12 @@
 # there is no need to expose that as a setting unless another implementation
 # arises. We also assume that the ActiveFedora and Blacklight cores are the
 # same here; another preceding default for a Blacklight URL could be added.
+default: &default
+  adapter: solr
+  url: <%= Settings.solr.url %>
 development:
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || Settings.solr.url %>
-test: &test
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || Settings.solr.url %>
+  <<: *default
+test:
+  <<: *default
 production:
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || Settings.solr.url %>
+  <<: *default

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -2,4 +2,10 @@
 Config.setup do |config|
   # Name of the constant exposing loaded settings
   config.const_name = 'Settings'
+  # Use ENV settings
+  config.use_env = true
+  config.env_prefix = 'DATACORE'
+  config.env_separator = '__'
+  config.env_converter = :downcase
+  config.env_parse_values = true
 end

--- a/config/initializers/ezid.rb
+++ b/config/initializers/ezid.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Ezid::Client.configure do |config|
-  config.host     = ENV['EZID_HOST'] || Settings.ezid.host
-  config.port     = ENV['EZID_PORT'] || Settings.ezid.port
-  config.user     = ENV['EZID_USER'] || Settings.ezid.user
-  config.password = ENV['EZID_PASSWORD'] || Settings.ezid.password
-  config.timeout  = ENV['EZID_TIMEOUT'] || Settings.ezid.timeout
-  config.default_shoulder = ENV['EZID_DEFAULT_SHOULDER'] || Settings.ezid.shoulder
+  config.host     = Settings.ezid.host
+  config.port     = Settings.ezid.port
+  config.user     = Settings.ezid.user
+  config.password = Settings.ezid.password
+  config.timeout  = Settings.ezid.timeout
+  config.default_shoulder = Settings.ezid.shoulder
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,12 +4,12 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = Settings.rails_max_threads
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        Settings.port
+port        ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers Settings.web_concurrency
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,12 +4,12 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads_count = Settings.rails_max_threads
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        Settings.port
 
 # Specifies the `environment` that Puma will run in.
 #
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+# workers Settings.web_concurrency
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -3,7 +3,7 @@
 
 # Literal values should never be committed to this file.
 default: &default
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] || Settings.rails.secret_key_base %>
+  secret_key_base: <%= Settings.rails.secret_key_base %>
 
 development:
   <<: *default

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,9 +34,9 @@ notification_email: <%= ENV['USER'] %>@iu.edu
 hyrax:
   # Settings for email contact form and deposit notification
   contact_email: <%= ENV['USER'] %>@iu.edu
-  minter_statefile: <%= ENV['MINTER_FILE'] || "/tmp/umrdr-minter-#{Time.now.min}#{Time.now.sec}" %>
+  minter_statefile: <%= "/tmp/umrdr-minter-#{Time.now.min}#{Time.now.sec}" %>
   # Redis namespace used in both Hyrax and Resque initializers
-  redis_namespace: <%= ENV['REDIS_NS'] || 'deepbluedata' %>
+  redis_namespace: deepbluedata
 
 # Fedora connection information.
 # These values are used in fedora.yml; no literals should appear there. Each

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,7 @@
-hostname: <%= ENV['APP_HOSTNAME'] || 'deepblue.local' %>
+hostname: 'deepblue.local'
 
 hyrax:
-  redis_namespace: <%= ENV['REDIS_NS'] || 'deepbluedata-dev' %>
+  redis_namespace: 'deepbluedata-dev'
 
 fedora:
   url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8984 %>/rest

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -4,10 +4,10 @@
 # they are compatible with a typical container-style approach, where default
 # ports on generic hostnames are used for each service/resource.
 
-hostname: <%= ENV['APP_HOSTNAME'] || 'deepblue.lib.umich.edu' %>
+hostname: 'deepblue.lib.umich.edu'
 
 hyrax:
-  redis_namespace: <%= ENV['REDIS_NS'] || 'deepbluedata-production' %>
+  redis_namespace: 'deepbluedata-production'
 
 fedora:
   url: http://fcrepo/fedora/rest

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,7 +1,7 @@
-hostname: <%= ENV['APP_HOSTNAME'] || 'test.deepblue.lib.umich.edu' %>
+hostname: 'test.deepblue.lib.umich.edu'
 
 hyrax:
-  redis_namespace: <%= ENV['REDIS_NS'] || 'deepbluedata-test' %>
+  redis_namespace: 'deepbluedata-test'
 
 fedora:
   url: http://127.0.0.1:<%= ENV['FCREPO_TEST_PORT'] || 8986 %>/rest

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -3,7 +3,7 @@
 # imported here, except for one-off testing.
 
 default: &default
-  url: <%= ENV['SOLR_URL'] || Settings.solr.url %>
+  url: <%= Settings.solr.url %>
 
 development:
   <<: *default

--- a/lib/devise/fake_auth_header.rb
+++ b/lib/devise/fake_auth_header.rb
@@ -17,7 +17,7 @@ class FakeAuthHeader
   # consideration for threads. different threads can have their own object
   # (a duped copy) and carry on their merry way.
   def _call env
-    env['HTTP_X_REMOTE_USER'] = ENV['USER']
+    env['HTTP_X_REMOTE_USER'] = Settings.user
     @app.call(env)
   end
 

--- a/lib/tasks/update_file_derivatives.rake
+++ b/lib/tasks/update_file_derivatives.rake
@@ -45,9 +45,9 @@ module Deepblue
       puts "ENV['TMPDIR']=#{ENV['TMPDIR']}"
       # puts "DeepBlueDocs::Application.config.tmpdir=#{DeepBlueDocs::Application.config.tmpdir}"
       puts "ENV['_JAVA_OPTIONS']=#{ENV['_JAVA_OPTIONS']}"
-      @tmpdir = Pathname.new "/deepbluedata-prep/fedora-extract"
+      @tmpdir = Pathname.new Settings.file_derivatives_dir
       Dir.mkdir @tmpdir unless Dir.exist? @tmpdir
-      @java_io_tmpdir = @tmpdir
+      @java_io_tmpdir = Pathname.new Settings.java_io_tmpdir
       Dir.mkdir @java_io_tmpdir unless Dir.exist? @java_io_tmpdir
       ENV['_JAVA_OPTIONS'] = '-Djava.io.tmpdir=' + ENV['TMPDIR']
       puts "ENV['_JAVA_OPTIONS']=#{ENV['_JAVA_OPTIONS']}"


### PR DESCRIPTION
Currently, many of the YAML configuration files follow a paradigm of trying to read an `ENV` value, then resorting to a configured one, with statements like:
url: <%= ENV['SOLR_URL'] || Settings.solr.url %>
This PR activates the [`Config` option to read `ENV` values](https://github.com/railsconfig/config#environment-variables) (if present) to override configured values.  This changes the paradigm slightly, and converts the above statement to one like:
url: <%= Settings.solr.url %>

Altogether, this gives us the following sequence of specifying configuration values, with lower-listed settings overriding preceding ones:
```
# files stored in git
config/settings.yml
config/settings/#{environment}.yml
config/environments/#{environment}.yml

# files ignored by git
config/settings.local.yml
config/settings/#{environment}.local.yml
config/environments/#{environment}.local.yml

# provided by running a .secrets.sh or somesuch
(ENV variables)
```
PR includes a `.secrets.sh.example` file.

In actual deployment, secret values could be provided by `*.local.yml` files, or setting `ENV` variables -- or even _both_, if there were some good reason to do that.