### PR TITLE
Move app to root

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -49,7 +49,7 @@ Hyrax.config do |config|
       maxNumberOfFiles: 100,
       # maxFileSize: 500.megabytes
       maxFileSize: 2.gigabytes,
-      url: Settings.relative_url_root + '/uploads'
+      url: '/uploads'
   }
 
   # Enable displaying usage statistics in the UI


### PR DESCRIPTION
This fixes the way javascript assets are build for file uploads. The previous code resulted in upload links like this: http://uploads/
This change means the app will need to be run at the root directory, not in a relative sub-directory (like data/). relative_url_root is set in config/settings.yml and with this change needs to be set to '/' (not '/data')

For this change to be realized in a deployed app, asset purge and re-compilation needs to be triggered with:
`rake tmp:cache:clear assets:clobber assets:precompile`