### PR TITLE
Replace Michigan-specific language, and turn raw link text to links

### DIFF
--- a/app/services/deepblue/doi_minting_service.rb
+++ b/app/services/deepblue/doi_minting_service.rb
@@ -4,7 +4,7 @@ module Deepblue
 
   class DoiMintingService
 
-    PUBLISHER = "University of Michigan".freeze
+    PUBLISHER = "Indiana University".freeze
     RESOURCE_TYPE = "Dataset".freeze
 
     attr :current_user, :work, :metadata

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,2 +1,3 @@
+<!-- deprecated -->
 <a href="<%=hyrax.root_path %>" class="site-link site-title-flex"><img class="site-logo" src="https://www.lib.umich.edu/falafel/v0/graphics/mlib_square__transparent.svg" alt="University of Michigan"><span class="site-title"><%= application_name %></span>
 </a>

--- a/app/views/hyrax/static/about.html.erb
+++ b/app/views/hyrax/static/about.html.erb
@@ -51,7 +51,7 @@
 
   <p><strong>We cannot accept:</strong></p>
   <ul>
-    <li>Data on human subjects or sensitive data. This includes data that are subject to export controls, present a conflict of interest for the University or the Researcher(s), or whose distribution would otherwise constitute a violation of research ethics or compliance. For HIPAA-aligned data storage options, see: https://compliance.iu.edu/compliance-areas/hipaa/index.html and https://kb.iu.edu/d/bcpd</li>
+    <li>Data on human subjects or sensitive data. This includes data that are subject to export controls, present a conflict of interest for the University or the Researcher(s), or whose distribution would otherwise constitute a violation of research ethics or compliance. For HIPAA-aligned data storage options, see: <a href="https://compliance.iu.edu/compliance-areas/hipaa/index.html">HIPAA Privacy and Security Compliance</a> and <a href="https://kb.iu.edu/d/bcpd">Types of sensitive institutional data appropriate for the Scholarly Data Archive at IU</a></li>
     <li>Data containing personally identifiable information that would prohibit public access.</li>
     <li>Administrative data, unless being used for research purposes and with prior consent and agreement of the IU Libraries.</li>
     <li>Data that is encrypted.</li>

--- a/config/locales/data_set.en.yml
+++ b/config/locales/data_set.en.yml
@@ -230,7 +230,7 @@ en:
           "Download Data from Globus"
         grantnumber: >
           If you have one, provide the grant number that was assigned by the University of Michigan’s Office of Research
-          and Sponsored Projects (ORSP).
+          and Sponsored Projects (ORSP). # FIXME
         identifier: >
           A unique handle identifying the work. An example would be a DOI for a journal article, or an ISBN or OCLC
           number for a book.

--- a/config/locales/deepblue.en.yml
+++ b/config/locales/deepblue.en.yml
@@ -139,7 +139,7 @@ en:
           Select the primary funding agency that supported the research and data collection from the drop-down list.
         grantnumber: >
           If you have one, provide the grant number that was assigned by the University of Michigan’s Office of Research
-          and Sponsored Projects (ORSP).
+          and Sponsored Projects (ORSP). # FIXME
         language: >
           List the language(s) in which the data and supplementary content are written; these could be spoken languages
           or formal languages, such as programming languages.


### PR DESCRIPTION
In draft status, pending replacement language for `grantnumber` field description:

If you have one, provide the grant number that was assigned by the University of Michigan’s Office of Research and Sponsored Projects (ORSP).

Replaces "University of Michigan" with "Indiana University" as `PUBLISHER` value in DOI Minting Service.

On the "About" page, replaces raw link text:
Data on human subjects or sensitive data. This includes data that are subject to export controls, present a conflict of interest for the University or the Researcher(s), or whose distribution would otherwise constitute a violation of research ethics or compliance. For HIPAA-aligned data storage options, see: https://compliance.iu.edu/compliance-areas/hipaa/index.html and https://kb.iu.edu/d/bcpd

with titled links:
Data on human subjects or sensitive data. This includes data that are subject to export controls, present a conflict of interest for the University or the Researcher(s), or whose distribution would otherwise constitute a violation of research ethics or compliance. For HIPAA-aligned data storage options, see: <a href="https://compliance.iu.edu/compliance-areas/hipaa/index.html">HIPAA Privacy and Security Compliance</a> and <a href="https://kb.iu.edu/d/bcpd">Types of sensitive institutional data appropriate for the Scholarly Data Archive at IU</a>

