### PR TITLE
:bug: route sda request filenames with composite suffixes

### DIFF
--- a/app/models/archive_file.rb
+++ b/app/models/archive_file.rb
@@ -10,7 +10,7 @@ class ArchiveFile
   # object may be either filename, or subdirs*/filename
   def initialize(collection:, object:)
     @collection = collection
-    @object = object
+    @object = object.sub(/\.$/, '') # "match" routing case can add terminal "."
   end
 
   def to_s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,7 +150,7 @@ Rails.application.routes.draw do
 
   get '/sda/request/(:collection)/(:object)', to: 'archive#download_request'
   get '/sda/status/(:collection)/(:object)', to: 'archive#status'
+  match '/sda/request/:collection/:object', to: 'archive#download_request', constraints: { object: /[^\/]+/ }, via: :get
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
 end


### PR DESCRIPTION
rails routing chokes on file.tar.gz and other multipart files; encode pre-final periods to "%2E"