### PR TITLE
[IUSW-2561] handle zero results in catalog

### DIFF
--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -1,11 +1,14 @@
-<%# unmodified from blacklight 6.25.0 %>
+<%# modified from blacklight 6.25.0 %>
 <h2><%= t 'blacklight.search.zero_results.title' %></h2>
 <div id="documents" class="noresults">
   <h3><%= t 'blacklight.search.zero_results.modify_search' %></h3>
   <ul>
     <li><%= t 'blacklight.search.zero_results.use_fewer_keywords' %></li>
 
-    <%- if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field.try(:key) -%>
+    <%# [IUSW-2561] below line errors out for mysterious reasons %>
+    <%# if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field.try(:key) -%>
+    <% default_search_key = (blacklight_config&.default_search_field&.respond_to?(:key) && blacklight_config.default_search_field.key) %>
+    <%- if params[:q] && params[:search_field] && (params[:search_field] != default_search_key) -%>
       <li><%= t 'blacklight.search.zero_results.search_fields', :search_fields => search_field_label(params) %> - 
       <%= link_to t('blacklight.search.zero_results.search_everything', field: blacklight_config.default_search_field.label), url_for(search_state.params_for_search(search_field: blacklight_config.default_search_field.key)) %>
       </li>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -1,0 +1,15 @@
+<%# unmodified from blacklight 6.25.0 %>
+<h2><%= t 'blacklight.search.zero_results.title' %></h2>
+<div id="documents" class="noresults">
+  <h3><%= t 'blacklight.search.zero_results.modify_search' %></h3>
+  <ul>
+    <li><%= t 'blacklight.search.zero_results.use_fewer_keywords' %></li>
+
+    <%- if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field.try(:key) -%>
+      <li><%= t 'blacklight.search.zero_results.search_fields', :search_fields => search_field_label(params) %> - 
+      <%= link_to t('blacklight.search.zero_results.search_everything', field: blacklight_config.default_search_field.label), url_for(search_state.params_for_search(search_field: blacklight_config.default_search_field.key)) %>
+      </li>
+    <%- end %>
+
+  </ul>
+</div>


### PR DESCRIPTION
Something mysterious and crash-y happens if you call #try(:key) on a blacklight search field object.