### PR TITLE
[IUS-2595] hold back redlock to prevent locking errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,9 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            gem update --system
-            gem update bundler
+            # skip below lines complaining about old ruby version holding back gem upgrades
+            # gem update --system
+            # gem update bundler
             bundle config path $CIRCLE_WORKING_DIRECTORY/vendor/bundle
             bundle install
             bundle pristine chromedriver-helper

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@
 
 source 'https://rubygems.org'
 
+# workarounds for gems failing to build
+gem 'libxml-ruby', '3.1.0', path: 'vendor/bundle/ruby/2.7.0/gems/libxml-ruby-3.1.0'
+gem "posix-spawn", github: "https://github.com/rtomayko/posix-spawn/pull/93"
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"
@@ -135,7 +139,7 @@ group :development, :test do
   gem 'solr_wrapper', '~> 2.1.0'
 end
 
-gem 'willow_sword', github: 'notch8/willow_sword'
+gem 'willow_sword', github: 'notch8/willow_sword', ref: '0a669d7'
 
 gem 'dotenv-rails'
 gem 'recaptcha'

--- a/Gemfile
+++ b/Gemfile
@@ -143,3 +143,4 @@ gem 'willow_sword', github: 'notch8/willow_sword', ref: '0a669d7'
 
 gem 'dotenv-rails'
 gem 'recaptcha'
+gem 'redlock', '~> 1.2' # redis locking fails on newer

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,12 @@
 source 'https://rubygems.org'
 
 # workarounds for gems failing to build
-gem 'libxml-ruby', '3.1.0', path: 'vendor/bundle/ruby/2.7.0/gems/libxml-ruby-3.1.0'
+require 'pathname'
+if Pathname.new('vendor/bundle/ruby/2.7.0/gems/libxml-ruby-3.1.0').exist?
+  gem 'libxml-ruby', '3.1.0', path: 'vendor/bundle/ruby/2.7.0/gems/libxml-ruby-3.1.0'
+else
+  gem 'libxml-ruby', '3.1.0'
+end
 gem "posix-spawn", github: "https://github.com/rtomayko/posix-spawn/pull/93"
 
 git_source(:github) do |repo_name|

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -811,12 +811,10 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.8.1)
-    redis-client (0.22.2)
-      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
-    redlock (2.0.6)
-      redis-client (>= 0.14.1, < 1.0.0)
+    redlock (1.3.2)
+      redis (>= 3.0.0, < 6.0)
     regexp_parser (2.9.3)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -1100,6 +1098,7 @@ DEPENDENCIES
   rails-controller-testing
   recaptcha
   redis (~> 4.0)
+  redlock (~> 1.2)
   resque
   resque-pool
   resque-scheduler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,19 @@
 GIT
   remote: https://github.com/notch8/willow_sword.git
-  revision: 74f7684ff9ca96251f341e50a3afc34b5bd312cc
+  revision: 0a669d78617c6003e4aa1a46a10447be92be27d5
+  ref: 0a669d7
   specs:
     willow_sword (0.2.0)
       bagit (~> 0.4.1)
       rails (>= 5.1.6)
       rubyzip (>= 1.0.0)
+
+GIT
+  remote: https://github.com/rtomayko/posix-spawn.git
+  revision: 0fce38ed5458b638eda5f3bb711903424a4366db
+  ref: refs/pull/93/head
+  specs:
+    posix-spawn (0.3.15)
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
@@ -25,6 +33,11 @@ GIT
       rails (>= 5.1.6)
       rdf (>= 2.0.2, < 4.0)
       simple_form
+
+PATH
+  remote: vendor/bundle/ruby/2.7.0/gems/libxml-ruby-3.1.0
+  specs:
+    libxml-ruby (3.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -556,7 +569,6 @@ GEM
       actionpack (>= 4)
       less (~> 2.6.0)
       sprockets (>= 2)
-    libxml-ruby (3.1.0)
     link_header (0.0.8)
     linkeddata (3.1.1)
       equivalent-xml (~> 0.6)
@@ -672,7 +684,6 @@ GEM
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)
-    posix-spawn (0.3.15)
     power_converter (0.1.2)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -1071,6 +1082,7 @@ DEPENDENCIES
   jira-ruby (~> 1.1)
   jquery-rails
   ldap_groups_lookup (~> 0.11.0)
+  libxml-ruby (= 3.1.0)!
   listen (~> 3.0.5)
   loofah (~> 2.19.1)
   mysql2
@@ -1078,6 +1090,7 @@ DEPENDENCIES
   okcomputer (~> 1.17)
   omniauth
   omniauth-cas
+  posix-spawn!
   pry
   pry-byebug
   pry-rails


### PR DESCRIPTION
The key change is locking to 1.x redlock, but along for the ride are:
* other Gemfile tweaks to get bundles installing across local, server, CircleCI environments
* modifying CircleCI builds to work around complaints against installing newer gems on an older ruby