### PR TITLE
[IUS-2597] DataCORE - Fix Collections list page links

### DIFF
--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -16,7 +16,7 @@
   </td>
   <td>
     <div class="thumbnail-title-wrapper">
-      <%= link_to collection_presenter.relative_url_root + collection_presenter.show_path do %>
+      <%= link_to collection_presenter.show_path do %>
           <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
           <%= collection_presenter.title_or_label %>
       <% end %>


### PR DESCRIPTION
Updated the url for the links on the 'All Collections' tab of the Dashboard page.