### PR TITLE
[IUS-2580] DataCORE - improve aesthetics of github/commit link on About page

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -860,6 +860,20 @@ div.facets h3 {
 
 /** Footer **/
 
+#footerGitHub {
+  background-color: $u-m-blue;
+  text-align: center;
+}
+
+#footerGitHub a {
+  color: #fff;
+  text-decoration: none;
+}
+
+#footerGitHub  a:hover {
+  color: #990000;
+}
+
 .footer {
   max-width: 100%;
   margin-top: 3em;

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,12 +1,13 @@
-<% if request.path.include?('about') %>
-    <ul class="rvt-footer__aux-links">
-      <li class="rvt-footer__aux-item">
-          <%= link_to(t('hyrax.product_name'), 'https://github.com/IUBLibTech/datacore') %>
-          <%= link_to(ENV['SOURCE_COMMIT'].to_s.truncate(9), "https://github.com/IUBLibTech/datacore/tree/#{ENV['SOURCE_COMMIT']}") if ENV['SOURCE_COMMIT'] %>
-      </li>
-    </ul>
-<% end %>
-<footer id="footer" role="contentinfo" itemscope="itemscope" itemtype="http://schema.org/CollegeOrUniversity">
+<footer id="footerGitHub">
+  <div>
+    <% if request.path.include?('about') %>
+      <%= link_to(t('hyrax.product_name'), 'https://github.com/IUBLibTech/datacore') %>
+      <%= link_to(ENV['SOURCE_COMMIT'].to_s.truncate(9).squish, "https://github.com/IUBLibTech/datacore/tree/#{ENV['SOURCE_COMMIT']}") if ENV['SOURCE_COMMIT'] %>
+    <% end %>
+  </div>
+</footer>
+
+  <footer id="footer" role="contentinfo" itemscope="itemscope" itemtype="http://schema.org/CollegeOrUniversity">
     <div class="row pad">
         <p class="signature">
             <a href="https://www.iu.edu/index.html" class="signature-link signature-img"><img src="//assets.iu.edu/brand/3.3.x/iu-sig-formal.svg" alt="Indiana University"/></a>


### PR DESCRIPTION
The github / commit link on the About page is now centered in a second, thin blue footer above the official IU footer instead of way off to the right side of the page.