### PR TITLE
[IUS-2614] Add site layout to 404 not found page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,6 +119,6 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::UnknownFormat, with: :rescue_404
 
   def rescue_404
-    render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
+    render file: Rails.public_path.join('404.html'), status: :not_found, layout: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,5 +152,9 @@ Rails.application.routes.draw do
   get '/sda/status/(:collection)/(:object)', to: 'archive#status'
   match '/sda/request/:collection/:object', to: 'archive#download_request', constraints: { object: /[^\/]+/ }, via: :get
 
+  # Send ActionController::RoutingError to 404 page
+  # Must be the last route defined
+  match '*unmatched', to: 'application#rescue_404', via: :all
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Now the '404 Not Found' page will show the header and search bar above the error message and the footer below.