### PR TITLE
[IUS-2609] DataCORE - Reload Work page to show Provenance Log

### DIFF
--- a/app/controllers/hyrax/data_sets_controller.rb
+++ b/app/controllers/hyrax/data_sets_controller.rb
@@ -284,7 +284,7 @@ module Hyrax
       Deepblue::LoggingHelper.bold_debug [ "DataSetsController", "display_provenance_log", file_path ]
       Deepblue::ProvenanceLogService.entries( curation_concern.id, refresh: true )
       # continue on to normal display
-      redirect_to [main_app, curation_concern]
+      redirect_to polymorphic_url([main_app, curation_concern], anchor: "prov_log")
     end
 
     def display_provenance_log_enabled?

--- a/app/views/_provenance_log_entries.html.erb
+++ b/app/views/_provenance_log_entries.html.erb
@@ -1,5 +1,5 @@
 <% if current_ability.admin? && @presenter.present? && @presenter.display_provenance_log_enabled? %>
-  <div class="panel panel-default panel-items panel-provenance-log-entries">
+  <div id="prov_log" class="panel panel-default panel-items panel-provenance-log-entries">
     <% if @presenter.provenance_log_entries? %>
       <% provenance_log_entries = Deepblue::ProvenanceLogService.entries( @presenter.id ) %>
       <% if provenance_log_entries.present? %>
@@ -46,4 +46,24 @@
       <% end %>
     <% end %>
   </div>
+
+  <script type="text/javascript" defer>
+      document.addEventListener('turbolinks:load', function() {
+          let anchor = getAnchor();
+          if ( anchor != null) {
+              scrollToAnchor(anchor);
+          }
+     });
+
+     function getAnchor() {
+         let anchor = document.URL.split('#');
+         return anchor.length > 1 ? anchor[1] : null;
+     }
+
+     function scrollToAnchor(hash) {
+         let element = $('#' + hash);
+         element[0].scrollIntoView();
+     }
+  </script>
+
 <% end %>


### PR DESCRIPTION
After the user clicks the "Display or Update Provenance Log Entries" button on a Work the page reloads/redirects.  
Now using an html anchor and javaScript to load showing the Provenance Log instead of the top of the page.