### PR TITLE
[IUS-2461] add hydra-role-management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
             bundle install
             bundle pristine chromedriver-helper
             bundle clean
+            bundle exec rake db:migrate RAILS_ENV=test
 
       - save_cache:
           paths:

--- a/Gemfile
+++ b/Gemfile
@@ -75,12 +75,6 @@ gem 'redis', '~> 4.0'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
-# Pinning Rack commit that resolves the large file upload issue
-# When 2.0.4 is out this might not be needed anymore
-# See: https://tools.lib.umich.edu/jira/browse/DBD-920
-#      https://tools.lib.umich.edu/jira/browse/HELIO-1450
-# gem 'rack', git: 'https://github.com/rack/rack.git', ref: 'ee01748'
-
 # Begin security vulnerability mitigation
 # bundle update --source gem-name
 gem 'bootstrap-sass', '~> 3.4.1'
@@ -95,7 +89,6 @@ gem 'sprockets', '~> 3.7.2'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
-  # gem 'rubocop'
   gem 'rubocop'
   gem 'rubocop-rspec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ gem 'okcomputer', '~> 1.17'
 gem 'omniauth'
 gem 'omniauth-cas'
 gem 'ldap_groups_lookup', '~> 0.11.0'
+gem 'hydra-role-management'
 gem 'riiif', '~> 1.1'
 gem 'rsolr', '>= 1.0'
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,9 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap_form (5.1.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (1.4.0)
       addressable (~> 2.5)
@@ -423,6 +426,13 @@ GEM
       active-fedora (>= 10)
       mime-types (>= 1)
       rdf-vocab
+    hydra-role-management (1.2.0)
+      blacklight (< 8)
+      bootstrap_form
+      bundler (>= 1.5)
+      cancancan
+      json (>= 1.8)
+      psych (~> 3.0)
     hydra-works (1.2.0)
       activesupport (>= 4.2.10, < 6.0)
       hydra-derivatives (~> 3.0)
@@ -693,6 +703,7 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
+    psych (3.3.4)
     public_suffix (5.1.1)
     pul_uv_rails (2.0.1)
     puma (6.5.0)
@@ -1075,6 +1086,7 @@ DEPENDENCIES
   factory_bot
   fcrepo_wrapper
   font-awesome-sass (~> 5.0)
+  hydra-role-management
   hyrax (~> 2.9)
   jbuilder (~> 2.5)
   jira-ruby (~> 1.1)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -44,6 +44,9 @@ class Ability
       cannot [:create, :edit, :update, :destroy], DataSet
       cannot [:create, :edit, :update, :destroy], FileSet
     end
+    if admin?
+      # can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role  # uncomment to expose Role management in UI
+    end 
   end
 
   def can_deposit?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -53,6 +53,10 @@ class Ability
     admin? || depositor?
   end
 
+  def admin?
+    current_user.admin? || super
+  end
+
   def depositor?
     depositing_role = Sipity::Role.find_by(name: Hyrax::RoleRegistry::DEPOSITING)
     return false unless depositing_role

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   # Connects this user object to Hydra behaviors.
   include Hydra::User
+  # Connects this user object to Role-management behaviors.
+  include Hydra::RoleManagement::UserRoles
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User
   include Hyrax::UserUsageStats

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,6 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-
   if Rails.configuration.authentication_method == "umich"
     devise_for :users, path: '', path_names: {sign_in: 'login', sign_out: 'logout'}, controllers: {sessions: 'sessions'}
   elsif Rails.configuration.authentication_method == "iu"
@@ -71,6 +70,7 @@ Rails.application.routes.draw do
 
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
+  # mount Hydra::RoleManagement::Engine => '/' # uncomment to expose Role management in UI
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
   curation_concerns_basic_routes

--- a/db/migrate/20250312164214_user_roles.rb
+++ b/db/migrate/20250312164214_user_roles.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class UserRoles < ActiveRecord::Migration[5.0]
+  def up
+    create_table :roles do |t|
+      t.string :name
+    end
+    create_table :roles_users, id: false do |t|
+      t.references :role
+      t.references :user
+    end
+    add_index :roles_users, %i[role_id user_id]
+    add_index :roles_users, %i[user_id role_id]
+  end
+
+  def down
+    drop_table :roles_users
+    drop_table :roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -283,6 +283,19 @@ ActiveRecord::Schema.define(version: 20190206172159) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "user_id"
+    t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+    t.index ["role_id"], name: "index_roles_users_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_roles_users_on_user_id"
+  end
+
   create_table "searches", force: :cascade do |t|
     t.binary   "query_params"
     t.integer  "user_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     factory :admin do
-      groups { ['admin'] }
+      roles { [Role.where(name: 'admin').first_or_create] }
     end
 
     factory :user_with_mail do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,30 +9,23 @@ RSpec.describe User, type: :model do
     describe ':user' do
       let(:user) { build(:user) }
 
-      it 'will, by default, have no groups' do
+      it 'will, by default, have only registered group' do
         expect(user.groups).to eq([])
         user.save!
         # Ensuring that we can refind it and have the correct groups
-        expect(user.class.find(user.id).groups).to eq([])
-      end
-      it 'will allow for override of groups' do
-        user = build(:user, groups: 'chicken')
-        expect(user.groups).to eq(['chicken'])
-        user.save!
-        # Ensuring that we can refind it and have the correct groups
-        expect(user.class.find(user.id).groups).to eq(['chicken'])
+        expect(user.class.find(user.id).groups).to eq(['registered'])
       end
     end
     describe ':admin' do
       let(:admin_user) { create(:admin) }
 
-      it 'will have an "admin" group' do
-        expect(admin_user.groups).to eq(['admin'])
+      it 'will be an "admin"' do
+        expect(admin_user.admin?).to be true
       end
       context 'when found from the database' do
-        it 'will have the expected "admin" group' do
+        it 'will be an "admin"' do
           refound_admin_user = described_class.find(admin_user.id)
-          expect(refound_admin_user.groups).to eq(['admin'])
+          expect(refound_admin_user.admin?).to be true
         end
       end
     end


### PR DESCRIPTION
Note that this requires a bit more deployment work that usual:

(1) bundle install, for the new gems

(2) run migrations, for the new table

(3) in console, assign admin roles:

```ruby
admin_role = Role.find_or_create_by(name: 'admin')
# set up admin_users array previously, through other means
admin_users.each do |admin_user|
  admin_user.roles << admin_role
  admin_user.save
end
```

Note that, unusually, I've modified a couple of files with changes that are (effectively) purely comments:
* app/models/ability.rb
* config/routes.rb

That's in an effort to clarify _doing_ all the recommended installation steps (as opposed to _missing_ one or more, inadvertently), but opting out of provided the UI for role management.  It's clunky, and rarely done enough that I think added security of needing to do it through console activity outweighs any benefits of providing UI access.