### PR TITLE
IUS-2638 DataCORE remove atom and rss feeds

### DIFF
--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,24 @@
+<h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
+
+<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render_opensearch_response_metadata %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+  <%= json_api_link_tag %>
+<% end %>
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+  <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+  <%= render_grouped_document_index %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -4,8 +4,6 @@
 
 <% content_for(:head) do -%>
   <%= render_opensearch_response_metadata %>
-  <%= rss_feed_link_tag %>
-  <%= atom_feed_link_tag %>
   <%= json_api_link_tag %>
 <% end %>
 


### PR DESCRIPTION
The links for the ATOM and RSS feeds on the search results page are broken.  Clearly they are not in use, so removing them for now so the page does not have broken links.  The json API link tag is working, so it stays.