### PR TITLE
[IUS-2733] DataCORE - Remove Download Files box when no files are present

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,7 +1,9 @@
 <div class="show-actions">
   <% if @presenter.tombstone.blank? %>
 
-    <%= render 'download_panel' %>
+    <% if @presenter.total_file_count > 0 %>
+      <%= render 'download_panel' %>
+    <% end %>
 
     <% if ((@presenter.editor? && @presenter.workflow.state != "deposited" ) ||
          @presenter.current_ability.admin? ) %>


### PR DESCRIPTION
Hiding the 'Download All Files' panel, including the 'Download Zipped Dataset' button, when no files have been added to the Data Set (yet).