### PR TITLE
IULRDC-173 DataCORE remove edit work for non-admins on Work view page

### DIFF
--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -24,6 +24,6 @@
       </table>
     </div>
 </div>
-<% elsif can? :edit, @presenter.id %>
+<% elsif @presenter.current_ability.admin? && @presenter.tombstone.blank? %>
     <div class="alert alert-warning" role="alert"><%= t('.empty', type: @presenter.human_readable_type) %></div>
 <% end %>

--- a/app/views/hyrax/base/_no_edit_panel.html.erb
+++ b/app/views/hyrax/base/_no_edit_panel.html.erb
@@ -1,0 +1,8 @@
+<div class="panel panel-default panel-edit">
+  <div class="panel-heading">
+    <h2>Edit Work</h2>
+  </div>
+  <div class="panel-body">
+    If you need to edit your work, contact the DataCORE team at: <a href="mailto:resdata@iu.edu">resdata@iu.edu</a>.
+  </div>
+</div>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -5,9 +5,10 @@
       <%= render 'download_panel' %>
     <% end %>
 
-    <% if ((@presenter.editor? && @presenter.workflow.state != "deposited" ) ||
-         @presenter.current_ability.admin? ) %>
+    <% if @presenter.current_ability.admin?  %>
       <%= render 'edit_panel' %>
+    <% elsif @presenter.editor? %>
+      <%= render 'no_edit_panel' %>
     <% end %>
 
     <% if Hyrax.config.analytics? %>


### PR DESCRIPTION
Only admins can see the Edit Work panel on the Work view page now.  If the Work is "pending review" a non-admin user can edit or delete it from the dashboard.  Non-admin users see a message now where the edit panel used to be unless the Work is Tombstoned.