### PR TITLE
[IULRDC-199] rescue errors in #send_an_email

### DIFF
--- a/app/helpers/deepblue/email_helper.rb
+++ b/app/helpers/deepblue/email_helper.rb
@@ -94,7 +94,7 @@ module Deepblue
       return if to.blank?
       return unless email_enabled
       email = DeepblueMailer.send_an_email( to: to, from: from, subject: subject, body: body )
-      email.deliver_now
+      email&.deliver_now
     end
 
     def self.user_email

--- a/app/mailers/deepblue_mailer.rb
+++ b/app/mailers/deepblue_mailer.rb
@@ -6,7 +6,12 @@ class DeepblueMailer < ApplicationMailer
   layout "mailer.html"
 
   def send_an_email( to:, from:, subject:, body: )
-    mail( to: to, from: from, subject: subject, body: body )
+    begin
+      mail( to: to, from: from, subject: subject, body: body )
+    rescue => e
+      Rails.logger.error "Error in DeepblueMailer#send_an_email"
+      Rails.logger.error "#{e.class}: #{e.inspect}"
+      nil
+    end
   end
-
 end


### PR DESCRIPTION
In the event of an error send a user notification email, this should allow workflow actions to complete, instead of getting cut off partway through.