### PR TITLE
IULRDC-200 DataCORE: Dashboard Settings submenu expansion issue

### DIFF
--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -25,3 +25,6 @@ Hyrax::HomepageController.prepend Extensions::Hyrax::HomepageController::Homepag
 
 # adding reCAPTCHA
 Hyrax::ContactFormController.prepend Extensions::Hyrax::ContactFormController::ContactFormRecaptcha
+
+# Additional presenter method for the Settings Dashboard sub-menu
+Hyrax::MenuPresenter.prepend Extensions::Hyrax::MenuPresenter::MenuPresenterBehavior

--- a/lib/extensions/hyrax/menu_presenter/menu_presenter_behavior.rb
+++ b/lib/extensions/hyrax/menu_presenter/menu_presenter_behavior.rb
@@ -1,0 +1,13 @@
+module Extensions
+  module Hyrax
+    module MenuPresenter
+      module MenuPresenterBehavior
+
+        def settings_section?
+          %w[appearances content_blocks features pages collection_types].include?(controller_name)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/extensions/hyrax/menu_presenter/menu_presenter_behavior.rb
+++ b/lib/extensions/hyrax/menu_presenter/menu_presenter_behavior.rb
@@ -4,7 +4,7 @@ module Extensions
       module MenuPresenterBehavior
 
         def settings_section?
-          %w[appearances content_blocks features pages collection_types].include?(controller_name)
+          %w[appearances content_blocks features pages collection_types rack_attacks robots].include?(controller_name)
         end
 
       end

--- a/spec/lib/extensions/hyrax/menu_presenter/menu_presenter_behavior_spec.rb
+++ b/spec/lib/extensions/hyrax/menu_presenter/menu_presenter_behavior_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+class MenuPresenterBehaviorMockParent
+
+  def controller_name
+  end
+end
+
+class MenuPresenterBehaviorMock < MenuPresenterBehaviorMockParent
+  include ::Extensions::Hyrax::MenuPresenter::MenuPresenterBehavior
+
+end
+
+
+
+describe Extensions::Hyrax::MenuPresenter::MenuPresenterBehavior do
+
+  subject { MenuPresenterBehaviorMock.new }
+
+  describe "#settings_section?" do
+
+    controller_names = %w[appearances collection_types pages content_blocks features rack_attacks robots]
+    controller_names.each do |controller_name|
+
+       context "when controller name #{controller_name} is in the settings section" do
+         before {
+           allow(subject).to receive(:controller_name).and_return controller_name
+         }
+
+         it "returns true" do
+           expect(subject.settings_section?).to eq true
+         end
+      end
+    end
+
+    context "when controller name is NOT in the settings section" do
+      before {
+        allow(subject).to receive(:controller_name).and_return "homepage"
+      }
+
+      it "returns false" do
+        expect(subject.settings_section?).to eq false
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
The DataCORE Dashboard ‘Settings' Sub-menu issue will now stay expanded for the (relatively) new ‘Rack Attack’ and ‘Robots.txt’ 'Settings Configuration’ pages.