### PR TITLE
[IULRDC-209] restrict zip_download

### DIFF
--- a/app/controllers/hyrax/data_sets_controller.rb
+++ b/app/controllers/hyrax/data_sets_controller.rb
@@ -380,7 +380,7 @@ module Hyrax
                                do_export_predicate: ->(_target_file_name, _target_file) { true },
                                quiet: false,
                                &block )
-        file_sets = curation_concern.file_sets
+        file_sets = curation_concern.file_sets.reject(&:exclude_from_zip?)
         Deepblue::ExportFilesHelper.export_file_sets( target_dir: target_dir,
                                                       file_sets: file_sets,
                                                       log_prefix: log_prefix,

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -197,14 +197,6 @@ class FileSet < ActiveFedora::Base
     return true
   end
 
-  def file_size_value
-    if file_size.blank?
-      original_file.nil? ? 0 : original_file.size
-    else
-      file_size[0]
-    end
-  end
-
   def original_name_value
     return '' if original_file.nil?
     return original_file.original_name if original_file.respond_to?( :original_name )

--- a/app/presenters/concerns/datacore/presents_archive_file.rb
+++ b/app/presenters/concerns/datacore/presents_archive_file.rb
@@ -1,11 +1,33 @@
 # frozen_string_literal: true
 
+# included in both FileSet and DsFileSetPresenter
 module Datacore
   module PresentsArchiveFile
 
     # archive files bypass fedora storage
     def archive_file?
       mime_type.to_s.match(/^message\/external-body\;.*access-type=URL/).present?
+    end
+
+    # file that should have bypassed fedora storage, but didn't
+    def large_file?
+      file_size_value > Settings.ingest.size_limit.fedora
+    end
+
+    def exclude_from_zip?
+      archive_file? || large_file?
+    end
+
+    # common interface across presenter, model
+    def file_size_value
+      case file_size
+      when Integer # DsFileSetPresenter, solr storage
+        file_size
+      when Array, ActiveTriples::Relation # FileSet storage
+        file_size.first.to_i
+      else # nil values, etc.
+        0
+      end
     end
 
     # needs to pass through archive_file in case any / to %2F encoding happened there

--- a/app/views/hyrax/base/_download_panel.html.erb
+++ b/app/views/hyrax/base/_download_panel.html.erb
@@ -7,13 +7,13 @@
       <% if Hyrax.config.download_files %>
         <% admin_or_not_embargo = ( @presenter.current_ability.admin? || @presenter.solr_document.visibility != "embargo" ) %>
         <% if @presenter.zip_download_enabled? && admin_or_not_embargo %>
-          <% if @presenter.member_presenters.all?(&:archive_file?) %>
+          <% if @presenter.member_presenters.all?(&:exclude_from_zip?) %>
             All files in this dataset must be individually downloaded.  This zip download will include the dataset metadata export, only.
-          <% elsif @presenter.member_presenters.any?(&:archive_file?) %>
+          <% elsif @presenter.member_presenters.any?(&:exclude_from_zip?) %>
             Some files in this dataset must be individually downloaded, and will not be included in the zip download:
             <ul>
-            <% @presenter.member_presenters.select(&:archive_file?).each do |archive_file| %>
-              <li><%= link_to archive_file.title&.first, hyrax.download_path(archive_file) %></li>
+            <% @presenter.member_presenters.select(&:exclude_from_zip?).each do |excluded_file| %>
+              <li><%= link_to excluded_file.first_title, hyrax.download_path(excluded_file) %></li>
             <% end %>
             </ul>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,9 @@ Rails.application.routes.draw do
         get    'globus_download_notify_me'
         post   'identifiers'
         post   'tombstone'
-        post   'zip_download'
+        if Settings.zip_download_enabled
+          post   'zip_download'
+        end
       end
     end
   end

--- a/spec/controllers/hyrax/data_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/data_sets_controller_spec.rb
@@ -97,4 +97,14 @@ RSpec.describe Hyrax::DataSetsController do
       end
     end
   end
+
+  describe "#export_file_sets_to" do
+    let(:controller) { described_class.new }
+    before { allow(controller).to receive(:curation_concern).and_return(data_set) }
+    before { allow(Deepblue::ExportFilesHelper).to receive(:export_file_sets).and_return(nil) }
+    it "delegates to ExportFilesHelper" do
+      expect(Deepblue::ExportFilesHelper).to receive(:export_file_sets)
+      controller.send(:export_file_sets_to, target_dir: 'target_dir')
+    end
+  end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -796,4 +796,6 @@ RSpec.describe FileSet do
   # end
   #
 
+  let(:archive_file_object) { FactoryBot.create(:file_set) }
+  include_examples "PresentsArchiveFile behaviors"
 end

--- a/spec/presenters/hyrax/ds_file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/ds_file_set_presenter_spec.rb
@@ -183,4 +183,7 @@ RSpec.describe Hyrax::DsFileSetPresenter do
        end
      }
   end
+
+  let(:archive_file_object) { presenter }
+  include_examples "PresentsArchiveFile behaviors"
 end

--- a/spec/presenters/hyrax/ds_file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/ds_file_set_presenter_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::DsFileSetPresenter do
+  let(:attributes) { { file_size_lts: 2048 } }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:ability) { Ability.new(FactoryBot.build(:user), {}) }
+  let(:request) { double(host: 'example.org', base_url: 'http://example.org') }
+  let(:presenter) { described_class.new(solr_document, ability, request) }
+
+  describe "delegates methods to solr_document:" do
+    [:file_size, :file_size_human_readable,
+     :original_checksum, :mime_type, :title, :virus_scan_service, :virus_scan_status, :virus_scan_status_date].each do
+    |method|
+      it "#{method}" do
+        expect(presenter).to delegate_method(method).to(:solr_document)
+      end
+    end
+  end
+
+  # NOTE:  relative_url_root function exactly the same in collection_presenter, work_show_presenter
+  describe "#relative_url_root" do
+    context "when DeepBlueDocs::Application.config.relative_url_root has value" do
+      before {
+        allow(DeepBlueDocs::Application.config).to receive(:relative_url_root).and_return "site root"
+      }
+      it "returns value" do
+        expect(DeepBlueDocs::Application.config).to receive(:relative_url_root)
+        expect(presenter.relative_url_root).to eq "site root"
+      end
+    end
+
+    context "when DeepBlueDocs::Application.config.relative_url_root is nil or false" do
+      before {
+        allow(DeepBlueDocs::Application.config).to receive(:relative_url_root).and_return false
+      }
+      it "returns empty string" do
+        expect(DeepBlueDocs::Application.config).to receive(:relative_url_root)
+        expect(presenter.relative_url_root).to be_blank
+      end
+    end
+  end
+
+  describe '#display_provenance_log_enabled?' do
+     it 'returns true' do
+        expect(presenter.display_provenance_log_enabled?).to eq true
+     end
+  end
+
+  # NOTE:  provenance_log_entries? function exactly the same in collection_presenter
+  describe "#provenance_log_entries?" do
+    context "calls Deepblue::ProvenancePath.path_for_reference" do
+      before {
+        allow(presenter).to receive(:id).and_return 1000
+        allow(Deepblue::ProvenancePath).to receive(:path_for_reference).with(1000).and_return "file_path"
+        allow(File).to receive(:exist?).with("file_path").and_return true
+      }
+      it "returns whether file path exists" do
+        expect(Deepblue::ProvenancePath).to receive(:path_for_reference)
+        expect(File).to receive(:exist?).with("file_path")
+
+        expect(presenter.provenance_log_entries?).to eq true
+      end
+    end
+  end
+
+  describe "#parent_public?" do
+    context "calls DataSet.find on parent.id" do
+      before {
+        allow(presenter).to receive(:parent).and_return OpenStruct.new(id: 333)
+        allow(DataSet).to receive(:find).with(333).and_return OpenStruct.new(public?: true)
+      }
+      it "returns value of public?" do
+        expect(DataSet).to receive(:find).with(333)
+        expect(presenter.parent_public?).to eq true
+      end
+    end
+  end
+
+  describe "#first_title" do
+    context "when the document has no title" do
+      before {
+        allow(presenter).to receive(:title).and_return([])
+      }
+      it "returns string \'File\'" do
+        expect(presenter.first_title).to eq "File"
+      end
+    end
+
+    context "when the document has at least one title" do
+      before {
+        allow(presenter).to receive(:title).and_return(["Descriptive Title", "Obtuse Title"])
+      }
+      it "returns first title" do
+        expect(presenter.first_title).to eq "Descriptive Title"
+      end
+    end
+  end
+
+  describe "#link_name" do
+    abilities = [{"admin" => true, "can" => true, "expected_result" => true},
+                 {"admin" => true, "can" => false, "expected_result" => true},
+                 {"admin" => false, "can" => true, "expected_result" => true},
+                 {"admin" => false, "can" => false, "expected_result" => false}]
+
+    before {
+      allow(presenter).to receive(:id).and_return 3000
+      allow(presenter).to receive(:first_title).and_return "Red Hot Spectacular"
+    }
+
+    abilities.each do |ability|
+      context "when current_ability.admin? is #{ability[:admin]} and current_ability.can?[:read id] is #{ability[:can]}" do
+        before {
+          allow(presenter.current_ability).to receive(:admin?).and_return ability[:admin]
+          allow(presenter.current_ability).to receive(:can?).with(:read, 3000).and_return ability[:can]
+        }
+
+        if ability[:expected_result]
+          it "calls first_title" do
+            expect(presenter).to receive(:first_title)
+            expect(presenter.link_name).to eq "Red Hot Spectacular"
+          end
+        else
+          it "returns string 'File'" do
+            expect(presenter.link_name).to eq "File"
+          end
+        end
+      end
+    end
+  end
+
+  describe "#file_name" do
+    before {
+      allow(presenter).to receive(:link_name).and_return "link name"
+    }
+
+    context "when tombstone has a value" do
+      it "return link_name" do
+        expect(presenter).not_to receive(:file_size_too_large_to_download?)
+        expect(presenter.file_name OpenStruct.new(tombstone: "monument"), "link to").to eq "link name"
+      end
+    end
+
+    context "when tombstone does not have a value and file_size_too_large_to_download?" do
+      before {
+        allow(presenter).to receive(:file_size_too_large_to_download?).and_return true
+      }
+      it "return link_name" do
+        expect(presenter).to receive(:file_size_too_large_to_download?)
+        expect(presenter.file_name OpenStruct.new(tombstone: nil), "link to").to eq "link name"
+      end
+    end
+
+    context "when tombstone does not have a value and not file_size_too_large_to_download?" do
+      before {
+        allow(presenter).to receive(:file_size_too_large_to_download?).and_return false
+      }
+      it "return link_to argument" do
+        expect(presenter).to receive(:file_size_too_large_to_download?)
+        expect(presenter.file_name OpenStruct.new(tombstone: nil), "link to").to eq "link to"
+      end
+    end
+  end
+
+  describe "#file_size_too_large_to_download?" do
+     expected_results = [OpenStruct.new(file_size: nil, expected_result: false, comparison: "file size is nil" ),
+                         OpenStruct.new(file_size: 6, expected_result: false, comparison: "file size is less than max_work_file_size_to_download" ),
+                         OpenStruct.new(file_size: 7, expected_result: true, comparison: "file size is equal to max_work_file_size_to_download" ),
+                         OpenStruct.new(file_size: 9, expected_result: true, comparison: "file size is greater than max_work_file_size_to_download" )]
+     before {
+       allow(DeepBlueDocs::Application.config).to receive(:max_work_file_size_to_download).and_return 7
+     }
+
+     expected_results.each { |n|
+       context "when #{n.comparison}" do
+         before {
+           presenter.instance_variable_set(:@solr_document, OpenStruct.new(file_size: n.file_size))
+         }
+         it "returns #{n.expected_result}" do
+           expect(presenter.file_size_too_large_to_download?).to eq(n.expected_result)
+         end
+       end
+     }
+  end
+end

--- a/spec/support/shared_examples/archive_file_behavior.rb
+++ b/spec/support/shared_examples/archive_file_behavior.rb
@@ -1,0 +1,49 @@
+RSpec.shared_examples "PresentsArchiveFile behaviors" do
+  # expects archive_file_object present as subject
+
+  describe "#file_size_value" do
+    it "returns an integer" do
+      expect(archive_file_object.file_size_value).to be_a Integer
+    end
+  end
+
+  describe "#large_file?" do
+    context "when file size is above fedora ingest limit" do
+      before { allow(Settings.ingest.size_limit).to receive(:fedora).and_return(-1) }
+      it "returns true" do
+        expect(archive_file_object.file_size_value).to be > Settings.ingest.size_limit.fedora
+        expect(archive_file_object.large_file?).to be true
+      end
+    end
+    context "when file size is below fedora ingest limit" do
+      it "returns false" do
+        expect(archive_file_object.file_size_value).to be < Settings.ingest.size_limit.fedora
+        expect(archive_file_object.large_file?).to be false
+      end
+    end
+  end
+
+  describe "#exclude_from_zip?" do
+    context "when an archived file" do
+      before { allow(archive_file_object).to receive(:archive_file?).and_return(true) }
+      it "returns true" do
+        expect(archive_file_object.archive_file?).to be true
+        expect(archive_file_object.exclude_from_zip?).to be true
+      end
+    end
+    context "when a large file" do
+      before { allow(archive_file_object).to receive(:large_file?).and_return(true) }
+      it "returns true" do
+        expect(archive_file_object.large_file?).to be true
+        expect(archive_file_object.exclude_from_zip?).to be true
+      end
+    end
+    context "when neither archived nor large" do
+      it "returns false" do
+        expect(archive_file_object.archive_file?).to be false
+        expect(archive_file_object.large_file?).to be false
+        expect(archive_file_object.exclude_from_zip?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
* removes zip_download from routing, when disabled via settings
* adds #large_file? method to detect Fedora-backed files that are above Fedora-storage size limit
* zip_download now excludes large files, in addition to archive (SDA-only) files