### PR TITLE
Revert earlier patch deprecated by #245

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -16,9 +16,6 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
-    # Do not store searches for anyone since Hyrax can't display them anyway
-    config.crawler_detector = ->(req) { true }
-
     config.view.gallery.partials = %i[index_header index]
     config.view.masonry.partials = [:index]
     config.view.slideshow.partials = [:index]


### PR DESCRIPTION
This reverts commit 5ef46e6db0f1288e9831674db33a72644d4d7b68 as that change is effectively covered by #245 